### PR TITLE
chore: add server port config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # 主URL配置
 MAIN_URLS=
+# 服务端口配置
+SERVER_PORT=3000
 
 # OneDrive配置
 onedrive_uid=

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -43,7 +43,7 @@ app.use('*', serveStatic({root: 'public/'}))
 
 serve({
     fetch: app.fetch,
-    port: 3000,
+    port: Number(process.env.SERVER_PORT) || 3000,
 })
 
 export default app


### PR DESCRIPTION
单独运行时支持配置服务端口，默认使用3000