### PR TITLE
fix(googleui): guard PROXY_API against undefined to prevent token fet…

### DIFF
--- a/src/basic.ts
+++ b/src/basic.ts
@@ -12,6 +12,7 @@ app.use('*', async(c, next)=>{
     c.env = {
         ...(c.env || {}),
         MAIN_URLS: process.env.MAIN_URLS || '',
+        PROXY_API: process.env.PROXY_API || '',
         baiduyun_ext: process.env.baiduyun_ext || '',
         onedrive_uid: process.env.onedrive_uid || '',
         onedrive_key: process.env.onedrive_key || '',

--- a/src/driver/googleui_oa.ts
+++ b/src/driver/googleui_oa.ts
@@ -53,9 +53,10 @@ export async function oneToken(c: Context) {
     let login_data, client_uid, client_key, random_key, server_use;
     let driver_txt, params_all, random_uid, server_url: string = driver_map[1];
     try { // 请求参数 ====================================================================
-        if (c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null"
-            && c.env.PROXY_API !== "none" && c.env.PROXY_API !== "false")
-            server_url = "https://" + c.env.PROXY_API + "/token";
+        const proxy_api = c.env.PROXY_API;
+        if (proxy_api && proxy_api.length > 3 && proxy_api !== "null"
+            && proxy_api !== "none" && proxy_api !== "false")
+            server_url = "https://" + proxy_api + "/token";
         login_data = <string>c.req.query('code');
         random_uid = <string>c.req.query('state');
         server_use = local.getCookie(c, 'server_use')
@@ -145,9 +146,10 @@ export async function genToken(c: Context) {
     const clients_info: configs.Clients | undefined = configs.getInfo(c);
     const refresh_text: string | undefined = c.req.query('refresh_ui');
     let server_url: string = driver_map[1];
-    if (c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null"
-        && c.env.PROXY_API !== "none" && c.env.PROXY_API !== "false")
-        server_url = "https://" + c.env.PROXY_API + "/token";
+    const proxy_api = c.env.PROXY_API;
+    if (proxy_api && proxy_api.length > 3 && proxy_api !== "null"
+        && proxy_api !== "none" && proxy_api !== "false")
+        server_url = "https://" + proxy_api + "/token";
     if (!clients_info) return c.json({text: "传入参数缺少"}, 500);
     if (!refresh_text) return c.json({text: "缺少刷新令牌"}, 500);
     // 请求参数 ==========================================================================


### PR DESCRIPTION
# 腾讯EdgeOne Google OAuth登录崩溃问题修复方案

## 问题背景

在腾讯 EdgeOne 部署环境下，Google 登录流程的回调、令牌刷新阶段程序崩溃，前端展示「授权失败」错误，无法正常获取 Token：

> 
> 授权失败，请检查:
> 1、应用ID和应用机密是否正确
> 2、登录账号是否具有应用权限
> 3、回调地址是否包括上面地址
> 错误信息: TypeError: Cannot read properties of undefined (reading 'length')

前置排查结论：
OAuth 授权链路本身无异常，回调地址配置、Google API 开关、OAuth 应用 ID/密钥均校验无误，使用谷歌官方工具可正常换取 Token。

## 根因定位

文件 `src/driver/googleui_oa.ts` 中 `oneToken`（令牌申请）、`genToken`（令牌刷新）函数直接读取 `c.env.PROXY_API.length`，未添加空值防护逻辑。

`PROXY_API` 为**可选环境变量**：仅国内节点需要代理谷歌 Token 接口时才需配置。
在 EdgeOne、Cloudflare 边缘运行时中，未配置的环境变量值为 `undefined`，直接访问 `.length` 会抛出类型错误；错误被全局 try/catch 捕获后，统一封装为「授权失败」提示展示给用户。

## 修复内容

### 1. 修复 `src/driver/googleui_oa.ts`

对 `oneToken`、`genToken` 两处读取 `PROXY_API` 的代码增加空值守卫逻辑：

```
// 修复前
if (c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null" ...)

// 修复后
const proxy_api = c.env.PROXY_API;
if (proxy_api && proxy_api.length > 3 && proxy_api !== "null" ...)
```

逻辑说明：

1. `PROXY_API` 未配置（值为 `undefined`/`null`/空字符串）：守卫短路生效，自动回退使用谷歌默认端点 `https://oauth2.googleapis.com/token`，不再触发崩溃；
2. `PROXY_API` 已配置且格式合法：原有代理逻辑完全保留，请求地址为 `https://<PROXY_API>/token`，行为无变更。

### 2. 补充 `src/basic.ts` Node.js 环境注入

Node.js 程序入口的环境变量注入中间件缺失 `PROXY_API` 字段，补充注入，保证 Cloudflare、EdgeOne、Node.js 三套运行时环境行为统一：

```
PROXY_API: process.env.PROXY_API || '',
```

## 验证结果

- ✅ EdgeOne 未配置 `PROXY_API`：`/googleui/callback` 回调接口可正常换取 Token
- ✅ EdgeOne 未配置 `PROXY_API`：`/googleui/renewapi` 刷新令牌接口正常执行
- ✅ 已配置合法 `PROXY_API`：代理转发逻辑与修复前完全一致，无功能退化
- ✅ TypeScript strict 严格模式编译无新增类型报错
- ✅ 仅修改 Google 驱动相关代码，不影响其他网盘驱动逻辑

## 影响范围

仅改动两处文件：

1. Google Drive OAuth 驱动：`src/driver/googleui_oa.ts`
2. Node.js 环境变量注入入口：`src/basic.ts`
其余网盘驱动、通用工具类逻辑无任何变更，无跨模块副作用。