### PR TITLE
fix(googleui): guard PROXY_API against undefined to prevent token fetch from failing when PROXY_API is unset

### DIFF
--- a/src/driver/googleui_oa.ts
+++ b/src/driver/googleui_oa.ts
@@ -53,7 +53,7 @@ export async function oneToken(c: Context) {
     let login_data, client_uid, client_key, random_key, server_use;
     let driver_txt, params_all, random_uid, server_url: string = driver_map[1];
     try { // 请求参数 ====================================================================
-        if (c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null"
+        if (c.env.PROXY_API && c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null"
             && c.env.PROXY_API !== "none" && c.env.PROXY_API !== "false")
             server_url = "https://" + c.env.PROXY_API + "/token";
         login_data = <string>c.req.query('code');
@@ -145,7 +145,7 @@ export async function genToken(c: Context) {
     const clients_info: configs.Clients | undefined = configs.getInfo(c);
     const refresh_text: string | undefined = c.req.query('refresh_ui');
     let server_url: string = driver_map[1];
-    if (c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null"
+    if (c.env.PROXY_API && c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null"
         && c.env.PROXY_API !== "none" && c.env.PROXY_API !== "false")
         server_url = "https://" + c.env.PROXY_API + "/token";
     if (!clients_info) return c.json({text: "传入参数缺少"}, 500);


### PR DESCRIPTION
# 腾讯EdgeOne Google OAuth登录崩溃问题修复方案

> 修复对应仓库提交：`aaeeb2d` fix(googleui): guard PROXY_API against undefined to prevent token fetch from failing when PROXY_API is unset

## 问题背景

在腾讯 EdgeOne 部署环境下，Google 登录流程的回调、令牌刷新阶段程序崩溃，前端展示「授权失败」错误，无法正常获取 Token：

> 
> 授权失败，请检查:
> 1、应用ID和应用机密是否正确
> 2、登录账号是否具有应用权限
> 3、回调地址是否包括上面地址
> 错误信息: TypeError: Cannot read properties of undefined (reading 'length')

前置排查结论：
OAuth 授权链路本身无异常，回调地址配置、Google API 开关、OAuth 应用 ID/密钥均校验无误，使用谷歌官方工具可正常换取 Token。

## 根因定位

文件 `src/driver/googleui_oa.ts` 中 `oneToken`（令牌申请，路由 `/googleui/callback`）、`genToken`（令牌刷新，路由 `/googleui/renewapi`）两处直接读取 `c.env.PROXY_API.length`（原第 56、148 行），未添加空值防护逻辑。

`PROXY_API` 为**可选环境变量**：仅国内节点需要代理谷歌 Token 接口（`https://oauth2.googleapis.com/token`）时才需配置。

各运行时对未配置变量的默认值处理不同，这也是问题仅在 EdgeOne 暴露的原因：

| 运行时 | 未配置时取值 | 说明 |
| --- | --- | --- |
| Cloudflare Workers | `""`（空字符串） | `wrangler.jsonc` 的 `vars` 中声明了 `"PROXY_API": ""`，`.length` 正常返回 0，不触发崩溃 |
| EdgeOne Pages | `undefined` | `functions/index.ts` 将 `context.env` 透传给 Hono，env 仅包含用户实际配置的变量，访问 `.length` 抛出 TypeError |
| Node.js | `undefined` | `src/basic.ts` 的环境注入中间件未包含 `PROXY_API`，`process.env` 中不存在该键 |

错误呈现路径：

- 回调 `oneToken`：该判断位于函数内第一个 `try` 块中，异常被捕获后经 `showErr()` 重定向到前端「授权失败」错误页（即用户看到的报错）；
- 刷新 `genToken`：该判断不在 `try` 块内，异常由 Hono `onError` 兜底返回 500。

## 修复内容

### 1. 修复 `src/driver/googleui_oa.ts`

对 `oneToken`、`genToken` 两处读取 `PROXY_API` 的代码增加空值守卫逻辑（两处条件判断各改 1 行，共 4 行）：

```
// 修复前（oneToken 第 56 行、genToken 第 148 行，两处写法相同）
if (c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null"
    && c.env.PROXY_API !== "none" && c.env.PROXY_API !== "false")

// 修复后（在读取 .length 前先判空）
if (c.env.PROXY_API && c.env.PROXY_API.length > 3 && c.env.PROXY_API !== "null"
    && c.env.PROXY_API !== "none" && c.env.PROXY_API !== "false")
```

逻辑说明：

1. `PROXY_API` 未配置（值为 `undefined`/`null`/空字符串）：`c.env.PROXY_API` 为假值，条件短路生效，自动回退使用谷歌默认端点 `https://oauth2.googleapis.com/token`，不再触发崩溃；
2. `PROXY_API` 已配置且格式合法（长度 > 3 且不为 "null"/"none"/"false"）：原有代理逻辑完全保留，请求地址为 `https://<PROXY_API>/token`，行为无变更。

另注：在 EdgeOne 控制台预先配置任意合法值（如 `none`）亦可临时规避该崩溃，但仅作为临时规避手段，代码守卫才是根本修复。

### 2. `src/basic.ts` Node.js 环境注入（可选加固，当前项目未应用）

`src/basic.ts` 第 11-35 行的环境变量注入中间件逐项注入了 `MAIN_URLS`、`googleui_uid` 等变量，但未包含 `PROXY_API` 字段。由于上述空值守卫已覆盖 `undefined` 场景，Node.js 运行时同样不会崩溃，本项不影响修复的有效性；如需 Cloudflare、EdgeOne、Node.js 三套运行时环境行为完全统一，可按既有变量的书写风格补充注入：

```
PROXY_API: process.env.PROXY_API || '',
```

## 验证结果

本地已验证：

- ✅ `npm install` 后执行 `npx tsc --noEmit` 全量类型检查通过，无新增类型报错
- ✅ 未配置 `PROXY_API`（`undefined`/空字符串）时守卫短路，回退谷歌默认端点，不再抛出 TypeError
- ✅ 修复已随提交 `aaeeb2d` 进入仓库主线，Cloudflare 端行为无变化

EdgeOne 部署后建议回归验证：

- 未配置 `PROXY_API`：`/googleui/callback` 回调接口可正常换取 Token
- 未配置 `PROXY_API`：`/googleui/renewapi` 刷新令牌接口正常执行
- 已配置合法 `PROXY_API`：代理转发逻辑与修复前完全一致，无功能退化

## 影响范围

仅改动 1 处文件：

1. Google Drive OAuth 驱动：`src/driver/googleui_oa.ts`（`oneToken`、`genToken` 两处条件判断，共 4 行）

其余网盘驱动、通用工具类逻辑无任何变更，无跨模块副作用。